### PR TITLE
fix: python 3 search on macOS

### DIFF
--- a/dependencies.cmake
+++ b/dependencies.cmake
@@ -39,7 +39,7 @@ set(EFFCEE_BUILD_TESTING OFF CACHE BOOL "" FORCE)
 set(EFFCEE_BUILD_SAMPLES OFF CACHE BOOL "" FORCE)
 AthenaAddDependency(
         TARGET_NAME effcee
-        GIT_URL https://github.com/google/effcee.git
-        GIT_TAG main
+        GIT_URL https://github.com/alexbatashev/effcee.git
+        GIT_TAG python3
         INCLUDE_PATH .
 )


### PR DESCRIPTION
Switch to a fork of effcee that enables modern CMake for macOS