### PR TITLE
feat: add backend support for Script Operation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ msbuild.wrn
 
 # Visual Studio 2015
 .vs/
+
+compile_commands.json
+
+.ccls-cache/

--- a/include/polarai/backend/generic/ScriptOperation.hpp
+++ b/include/polarai/backend/generic/ScriptOperation.hpp
@@ -1,0 +1,38 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 PolarAI. All rights reserved.
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <polar_backend_generic_export.h>
+#include <polarai/core/operation/Operation.hpp>
+
+namespace polarai::backend::generic {
+namespace internal {
+class ScriptOperationInternal;
+}
+class POLAR_BACKEND_GENERIC_EXPORT ScriptOperation : public core::Operation {
+public:
+  using InternalType = internal::ScriptOperationInternal;
+  enum Arguments {
+    ARG0 = 100,
+    ARG1,
+    ARG2,
+    ARG3,
+    ARG4,
+    ARG5,
+    ARG6,
+    ARG7,
+    ARG8,
+    ARG9
+  };
+};
+} // namespace polarai::backend::generic

--- a/src/backend/generic/lib/CMakeLists.txt
+++ b/src/backend/generic/lib/CMakeLists.txt
@@ -30,7 +30,8 @@ add_polar_library(polar_backend_generic SHARED
         GenericExecutor.cpp
         GraphPartitionPlanner.cpp
         allocators/LayerAllocator.cpp
-        CodeGen.cpp)
+        CodeGen.cpp
+        ScriptOperationInternal.cpp)
 
 add_library(PolarAI::generic_backend ALIAS polar_backend_generic)
 

--- a/src/backend/generic/lib/ScriptOperationInternal.cpp
+++ b/src/backend/generic/lib/ScriptOperationInternal.cpp
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 PolarAI. All rights reserved.
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#include "ScriptOperationInternal.hpp"
+#include <polarai/backend/generic/ScriptOperation.hpp>
+#include <polarai/core/node/internal/AbstractNodeInternal.hpp>
+#include <polarai/core/node/internal/NodeInternal.hpp>
+#include <polarai/loaders/internal/ConstantLoaderInternal.hpp>
+
+using namespace polarai::core::internal;
+
+namespace polarai::backend::generic::internal {
+ScriptOperationInternal::ScriptOperationInternal(
+    utils::WeakPtr<core::internal::ContextInternal> context,
+    utils::Index publicNodeIndex, utils::String program, size_t numArgs,
+    ShapeInferenceCallback scb, BuildDerivativeCallback dcb)
+    : core::internal::OperationInternal(std::move(context), publicNodeIndex,
+                                        "ScriptOperation"),
+      mNumOperands(numArgs), mShapeInference(scb), mDerivativeCallback(dcb) {}
+
+utils::Index ScriptOperationInternal::createResultTensor(
+    utils::SharedPtr<core::internal::ContextInternal> context,
+    const std::unordered_map<int64_t, utils::Index>& mapMarkToLocalTensorIndex,
+    const std::vector<core::internal::TensorInternal*>& tensors) const {
+  return mShapeInference(context, mapMarkToLocalTensorIndex, tensors);
+}
+
+core::internal::GenValue ScriptOperationInternal::gen(
+    utils::SharedPtr<core::internal::ContextInternal> context,
+    core::internal::Generator& generator,
+    const std::unordered_map<int64_t, utils::Index>& mapMarkToLocalTensorIndex,
+    const std::vector<core::internal::TensorInternal*>& tensors,
+    const core::internal::TensorInternal* resultTensor,
+    core::internal::GenNode parentNode) const {
+  generator.setInsertionPoint(parentNode);
+
+  // TODO implement
+
+  return GenValue{};
+}
+
+std::tuple<utils::Index, std::vector<core::internal::Edge>,
+           std::vector<utils::Index>>
+ScriptOperationInternal::genDerivative(
+    const core::NodeState* inputNodeState,
+    const core::NodeState* currentNodeState, size_t indexOfOutputDependence,
+    utils::Index gradientGraphFinalNodeIndex) const {
+  return mDerivativeCallback(inputNodeState, currentNodeState,
+                             indexOfOutputDependence,
+                             gradientGraphFinalNodeIndex);
+}
+
+size_t ScriptOperationInternal::getOperandsCount() const {
+  return mNumOperands;
+}
+} // namespace polarai::backend::generic::internal

--- a/src/backend/generic/lib/ScriptOperationInternal.hpp
+++ b/src/backend/generic/lib/ScriptOperationInternal.hpp
@@ -1,0 +1,71 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 PolarAI. All rights reserved.
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <polar_backend_generic_export.h>
+#include <polarai/core/context/internal/ContextInternal.hpp>
+#include <polarai/core/operation/internal/OperationInternal.hpp>
+#include <polarai/utils/allocator/Allocator.hpp>
+
+namespace polarai::backend::generic::internal {
+class POLAR_BACKEND_GENERIC_EXPORT ScriptOperationInternal
+    : public core::internal::OperationInternal {
+public:
+  using ShapeInferenceCallback = std::function<utils::Index(
+      utils::SharedPtr<core::internal::ContextInternal>,
+      const std::unordered_map<int64_t, utils::Index>&,
+      const std::vector<core::internal::TensorInternal*>&)>;
+  using BuildDerivativeCallback =
+      std::function<std::tuple<utils::Index, std::vector<core::internal::Edge>,
+                               std::vector<utils::Index>>(
+          const core::NodeState*, const core::NodeState*, size_t,
+          utils::Index)>;
+  ScriptOperationInternal(
+      utils::WeakPtr<core::internal::ContextInternal> context,
+      utils::Index publicNodeIndex, utils::String program, size_t numArgs,
+      ShapeInferenceCallback cb, BuildDerivativeCallback);
+
+  ~ScriptOperationInternal() override = default;
+
+  [[nodiscard]] utils::Index
+  createResultTensor(utils::SharedPtr<core::internal::ContextInternal> context,
+                     const std::unordered_map<int64_t, utils::Index>&
+                         mapMarkToLocalTensorIndex,
+                     const std::vector<core::internal::TensorInternal*>&
+                         tensors) const override;
+
+  core::internal::GenValue
+  gen(utils::SharedPtr<core::internal::ContextInternal> context,
+      core::internal::Generator& generator,
+      const std::unordered_map<int64_t, utils::Index>&
+          mapMarkToLocalTensorIndex,
+      const std::vector<core::internal::TensorInternal*>& tensors,
+      const core::internal::TensorInternal* resultTensor,
+      core::internal::GenNode parentNode) const override;
+
+  // output node and edges of generated graph
+  std::tuple<utils::Index, std::vector<core::internal::Edge>,
+             std::vector<utils::Index>>
+  genDerivative(const core::NodeState* inputNodeState,
+                const core::NodeState* currentNodeState,
+                size_t indexOfOutputDependence,
+                utils::Index gradientGraphFinalNodeIndex) const override;
+
+  [[nodiscard]] virtual size_t getOperandsCount() const override;
+
+private:
+  size_t mNumOperands;
+  ShapeInferenceCallback mShapeInference;
+  BuildDerivativeCallback mDerivativeCallback;
+};
+} // namespace polarai::backend::generic::internal


### PR DESCRIPTION
Script Operation is a way for users to define custom operations with
custom OpenCL C-like scripting language. This patch only adds user
accessible APIs. Compiler support is coming in other patches.