### PR TITLE
refactor: make Executor ABI-friendly

### DIFF
--- a/include/polarai/backend/generic/Executor.hpp
+++ b/include/polarai/backend/generic/Executor.hpp
@@ -12,32 +12,33 @@
 
 #pragma once
 
+#include <polar_backend_generic_export.h>
 #include <polarai/backend/generic/BackendAllocator.hpp>
 #include <polarai/backend/generic/runtime/Device.hpp>
+#include <polarai/core/graph/Graph.hpp>
 #include <polarai/core/graph/Traversal.hpp>
-#include <polarai/core/internal/Executor.hpp>
 #include <polarai/core/loader/internal/TensorAllocator.hpp>
-#include <polar_backend_generic_export.h>
+#include <polarai/utils/Pointer.hpp>
+#include <polarai/utils/storages/Vector.hpp>
 
 namespace polarai::backend::generic {
 
 // Forward declarations
-class PolarJIT;
-class RuntimeDriver;
-
+class ExecutorImpl;
 /// Default device filter. Selects all devices.
-constexpr auto DefaultDeviceFilter = [](std::shared_ptr<Device>&) {
+constexpr auto DefaultDeviceFilter = [](polarai::utils::SharedPtr<Device>&) {
   return true;
 };
 
 /**
  * Execute Graph with LLVM-based backend
  */
-class POLAR_BACKEND_GENERIC_EXPORT GenericExecutor {
+class POLAR_BACKEND_GENERIC_EXPORT Executor {
 public:
-  using FilterFunctionT = std::function<bool(std::shared_ptr<Device>&)>;
-  GenericExecutor(bool enableDebugOutput = false,
-               FilterFunctionT filter = DefaultDeviceFilter);
+  using FilterFunctionT =
+      std::function<bool(polarai::utils::SharedPtr<Device>&)>;
+  Executor(bool enableDebugOutput = false,
+           FilterFunctionT filter = DefaultDeviceFilter);
 
   /// Adds Graph to compilable module.
   ///
@@ -50,22 +51,12 @@ public:
   void evaluate(polarai::core::Graph& graph);
 
   BackendAllocator& getAllocator();
-  std::shared_ptr<BackendAllocator> getAllocatorPtr();
-  void setAllocator(std::shared_ptr<BackendAllocator>& allocator);
+  polarai::utils::SharedPtr<BackendAllocator> getAllocatorPtr();
+  void setAllocator(polarai::utils::SharedPtr<BackendAllocator>& allocator);
 
-  std::vector<std::shared_ptr<Device>>& getDevices();
-
-  void addModule(std::string_view module);
-
-  void execute(std::string_view name, void* userData);
+  polarai::utils::Vector<std::shared_ptr<Device>>& getDevices();
 
 private:
-  FilterFunctionT mFilter;
-  // Driver must come first to ensure proper shutdown
-  std::shared_ptr<RuntimeDriver> mRuntimeDriver;
-  std::vector<std::shared_ptr<Device>> mDevices;
-
-  std::shared_ptr<PolarJIT> mJITCompiler{nullptr};
-  std::shared_ptr<BackendAllocator> mAllocator;
+  polarai::utils::SharedPtr<ExecutorImpl> mImpl;
 };
-} // namespace polarai::backend::llvm
+} // namespace polarai::backend::generic

--- a/include/polarai/utils/storages/Vector.hpp
+++ b/include/polarai/utils/storages/Vector.hpp
@@ -1,0 +1,21 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 PolarAI. All rights reserved.
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <vector>
+
+namespace polarai::utils {
+// todo implement ABI-stable Vector
+template <typename T> using Vector = std::vector<T>;
+} // namespace polarai::utils
+

--- a/src/backend/generic/lib/CMakeLists.txt
+++ b/src/backend/generic/lib/CMakeLists.txt
@@ -27,7 +27,8 @@ message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
 add_subdirectory(jit)
 
 add_polar_library(polar_backend_generic SHARED
-        GenericExecutor.cpp
+        Executor.cpp
+        ExecutorImpl.cpp
         GraphPartitionPlanner.cpp
         allocators/LayerAllocator.cpp
         CodeGen.cpp

--- a/src/backend/generic/lib/Executor.cpp
+++ b/src/backend/generic/lib/Executor.cpp
@@ -1,0 +1,41 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 PolarAI. All rights reserved.
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#include "ExecutorImpl.hpp"
+
+#include <polarai/backend/generic/Executor.hpp>
+
+using namespace polarai::core;
+
+namespace polarai::backend::generic {
+
+void Executor::addGraph(Graph& graph) { mImpl->addGraph(graph); }
+
+void Executor::evaluate(Graph& graph) { mImpl->evaluate(graph); }
+
+Executor::Executor(bool enableDebugOutput, FilterFunctionT filter)
+    : mImpl(polarai::utils::makeShared<ExecutorImpl>(enableDebugOutput,
+                                                     std::move(filter))) {}
+
+BackendAllocator& Executor::getAllocator() { return mImpl->getAllocator(); }
+std::shared_ptr<BackendAllocator> Executor::getAllocatorPtr() {
+  return mImpl->getAllocatorPtr();
+}
+
+void Executor::setAllocator(std::shared_ptr<BackendAllocator>& allocator) {
+  mImpl->setAllocator(allocator);
+}
+
+std::vector<std::shared_ptr<Device>>& Executor::getDevices() {
+  return mImpl->getDevices();
+}
+} // namespace polarai::backend::generic

--- a/src/backend/generic/lib/ExecutorImpl.hpp
+++ b/src/backend/generic/lib/ExecutorImpl.hpp
@@ -1,0 +1,64 @@
+//===----------------------------------------------------------------------===//
+// Copyright (c) 2020 PolarAI. All rights reserved.
+//
+// Licensed under MIT license.
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+//===----------------------------------------------------------------------===//
+
+#pragma once
+
+#include <polar_backend_generic_export.h>
+#include <polarai/backend/generic/BackendAllocator.hpp>
+#include <polarai/backend/generic/runtime/Device.hpp>
+#include <polarai/core/graph/Traversal.hpp>
+#include <polarai/core/internal/Executor.hpp>
+#include <polarai/core/loader/internal/TensorAllocator.hpp>
+#include <polarai/utils/Pointer.hpp>
+#include <polarai/utils/storages/Vector.hpp>
+
+namespace polarai::backend::generic {
+
+// Forward declarations
+class PolarJIT;
+class RuntimeDriver;
+
+/**
+ * Execute Graph with LLVM-based backend
+ */
+class POLAR_BACKEND_GENERIC_EXPORT ExecutorImpl {
+public:
+  using FilterFunctionT =
+      std::function<bool(polarai::utils::SharedPtr<Device>&)>;
+  ExecutorImpl(bool enableDebugOutput, FilterFunctionT filter);
+
+  /// Adds Graph to compilable module.
+  ///
+  /// \param graph is a valid Graph to be compiled.
+  void addGraph(polarai::core::Graph& graph);
+
+  /// Executes particular graph.
+  ///
+  /// \param graph is a valid Graph, that has been previously added.
+  void evaluate(polarai::core::Graph& graph);
+
+  BackendAllocator& getAllocator();
+  polarai::utils::SharedPtr<BackendAllocator> getAllocatorPtr();
+  void setAllocator(polarai::utils::SharedPtr<BackendAllocator>& allocator);
+
+  polarai::utils::Vector<polarai::utils::SharedPtr<Device>>& getDevices();
+
+private:
+  FilterFunctionT mFilter;
+  // Driver must come first to ensure proper shutdown
+  std::shared_ptr<RuntimeDriver> mRuntimeDriver;
+  std::vector<std::shared_ptr<Device>> mDevices;
+
+  std::shared_ptr<PolarJIT> mJITCompiler{nullptr};
+  std::shared_ptr<BackendAllocator> mAllocator;
+};
+} // namespace polarai::backend::generic

--- a/src/backend/generic/lib/ExecutorImpl.hpp
+++ b/src/backend/generic/lib/ExecutorImpl.hpp
@@ -12,7 +12,6 @@
 
 #pragma once
 
-#include <polar_backend_generic_export.h>
 #include <polarai/backend/generic/BackendAllocator.hpp>
 #include <polarai/backend/generic/runtime/Device.hpp>
 #include <polarai/core/graph/Traversal.hpp>
@@ -30,7 +29,7 @@ class RuntimeDriver;
 /**
  * Execute Graph with LLVM-based backend
  */
-class POLAR_BACKEND_GENERIC_EXPORT ExecutorImpl {
+class ExecutorImpl {
 public:
   using FilterFunctionT =
       std::function<bool(polarai::utils::SharedPtr<Device>&)>;

--- a/tests/integration/operations/AddOperation.cpp
+++ b/tests/integration/operations/AddOperation.cpp
@@ -46,7 +46,7 @@ TEST_F(OperationTest, AddOp1D) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 
@@ -91,7 +91,7 @@ TEST_F(OperationTest, AddOp2D) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/CombineOperation.cpp
+++ b/tests/integration/operations/CombineOperation.cpp
@@ -57,7 +57,7 @@ TEST_F(OperationTest, Combine) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/Conv2DOperation.cpp
+++ b/tests/integration/operations/Conv2DOperation.cpp
@@ -64,7 +64,7 @@ TEST_F(OperationTest, Conv2D) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/DivideOperation.cpp
+++ b/tests/integration/operations/DivideOperation.cpp
@@ -56,7 +56,7 @@ TEST_F(OperationTest, Divide) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/LogLossOperation.cpp
+++ b/tests/integration/operations/LogLossOperation.cpp
@@ -61,7 +61,7 @@ TEST_F(OperationTest, DISABLED_LogLoss) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/MatMulOperation.cpp
+++ b/tests/integration/operations/MatMulOperation.cpp
@@ -84,7 +84,7 @@ TEST_F(OperationTest, MatMulNN) {
   graph.connect(node, out, Operation::Unmarked);
 
   withEachDeviceDo(
-      [&graph, out, &context, &target, m, n](GenericExecutor& executor) {
+      [&graph, out, &context, &target, m, n](Executor& executor) {
         executor.addGraph(graph);
         executor.evaluate(graph);
 
@@ -130,7 +130,7 @@ TEST_F(OperationTest, MatMulNNSquare) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 
@@ -177,7 +177,7 @@ TEST_F(OperationTest, MatMulNNRect) {
   graph.connect(node, out, Operation::Unmarked);
 
   withEachDeviceDo(
-      [&graph, out, &context, &target, m, n](GenericExecutor& executor) {
+      [&graph, out, &context, &target, m, n](Executor& executor) {
         executor.addGraph(graph);
         executor.evaluate(graph);
 
@@ -223,7 +223,7 @@ TEST_F(OperationTest, MatMulTNRect) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
   withEachDeviceDo(
-      [&graph, out, &context, &target, m, n](GenericExecutor& executor) {
+      [&graph, out, &context, &target, m, n](Executor& executor) {
         executor.addGraph(graph);
         executor.evaluate(graph);
 
@@ -270,7 +270,7 @@ TEST_F(OperationTest, MatMulNTRect) {
   graph.connect(node, out, Operation::Unmarked);
 
   withEachDeviceDo(
-      [&graph, out, &context, &target, m, n](GenericExecutor& executor) {
+      [&graph, out, &context, &target, m, n](Executor& executor) {
         executor.addGraph(graph);
         executor.evaluate(graph);
 

--- a/tests/integration/operations/MulConcatOperation.cpp
+++ b/tests/integration/operations/MulConcatOperation.cpp
@@ -57,7 +57,7 @@ TEST_F(OperationTest, MulConcat) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/MulOperation.cpp
+++ b/tests/integration/operations/MulOperation.cpp
@@ -56,7 +56,7 @@ TEST_F(OperationTest, Mul) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/OperationTest.hpp
+++ b/tests/integration/operations/OperationTest.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <polarai/backend/generic/GenericExecutor.hpp>
+#include <polarai/backend/generic/Executor.hpp>
 #include <runtime/driver/RuntimeDriver.hpp>
 
 #include <gtest/gtest.h>
@@ -8,7 +8,7 @@
 class OperationTest : public ::testing::Test {
 private:
   using CallbackT =
-      std::function<void(polarai::backend::generic::GenericExecutor&)>;
+      std::function<void(polarai::backend::generic::Executor&)>;
 
 protected:
   polarai::backend::generic::RuntimeDriver mDriver{false};
@@ -27,7 +27,7 @@ protected:
                    dev->getDeviceName() == device->getDeviceName();
           };
 
-      polarai::backend::generic::GenericExecutor executor(true, selector);
+      polarai::backend::generic::Executor executor(true, selector);
       cb(executor);
     }
   }

--- a/tests/integration/operations/Pool2DOperation.cpp
+++ b/tests/integration/operations/Pool2DOperation.cpp
@@ -54,7 +54,7 @@ TEST_F(OperationTest, Pool2D) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/ReLUOperation.cpp
+++ b/tests/integration/operations/ReLUOperation.cpp
@@ -53,7 +53,7 @@ TEST_F(OperationTest, ReLU) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/SigmoidOperation.cpp
+++ b/tests/integration/operations/SigmoidOperation.cpp
@@ -56,7 +56,7 @@ TEST_F(OperationTest, DISABLED_Sigmoid) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 

--- a/tests/integration/operations/SoftmaxOperation.cpp
+++ b/tests/integration/operations/SoftmaxOperation.cpp
@@ -53,7 +53,7 @@ TEST_F(OperationTest, Softmax) {
   auto out = graph.create<OutputNode>("out");
   graph.connect(node, out, Operation::Unmarked);
 
-  withEachDeviceDo([&graph, out, &context, &target](GenericExecutor& executor) {
+  withEachDeviceDo([&graph, out, &context, &target](Executor& executor) {
     executor.addGraph(graph);
     executor.evaluate(graph);
 


### PR DESCRIPTION
Generic Executor now has pimpl to be ABI-friendly. Also rename it
to simply Executor for brevity.